### PR TITLE
ignore Topic if it does not exist, since plone.app.collection might be installed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ New:
 
 Fixes:
 
-- *add item here*
+- Ignore the Topic content type, since it may not be available if
+  plone.app.collection is installed
+  [cdw9]
 
 
 1.5.12 (2015-10-28)

--- a/Products/CMFPlacefulWorkflow/DefaultWorkflowPolicy.py
+++ b/Products/CMFPlacefulWorkflow/DefaultWorkflowPolicy.py
@@ -276,7 +276,8 @@ class DefaultWorkflowPolicyDefinition(SimpleItemWithProperties):
         """
         # Verify input data
         if portal_type not in [pt.id for pt in self._listTypeInfo()]:
-            raise ValueError, ("'%s' is not a valid portal type." % portal_type)
+            if portal_type != 'Topic':
+                raise ValueError, ("'%s' is not a valid portal type." % portal_type)
 
         if type(chain) is type(''):
             chain = map( lambda x: x.strip(), chain.split(',') )


### PR DESCRIPTION
The xml files in default/portal_placeful_workflow have the `Topic` content type, but this may not be available if plone.app.collection is installed