### PR TITLE
Fixed workflow tests for new comment_one_state_workflow. [1.5, Plone 4.3]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ New:
 
 Fixes:
 
-- *add item here*
+- Fixed workflow tests for new ``comment_one_state_workflow``.  [maurits]
 
 
 1.5.13 (2016-01-08)

--- a/Products/CMFPlacefulWorkflow/tests/testCMFPlacefulWorkflow.py
+++ b/Products/CMFPlacefulWorkflow/tests/testCMFPlacefulWorkflow.py
@@ -642,10 +642,15 @@ class TestPlacefulWorkflow(CMFPlacefulWorkflowTestCase):
 
         self.failUnlessEqual(
             sorted(tuple(keys)),
-            sorted(('folder_workflow',
-                    'plone_workflow', 'intranet_folder_workflow',
-                    'one_state_workflow', 'simple_publication_workflow',
-                    'intranet_workflow')))
+            sorted((
+                'comment_one_state_workflow',
+                'folder_workflow',
+                'intranet_folder_workflow',
+                'intranet_workflow',
+                'one_state_workflow',
+                'plone_workflow',
+                'simple_publication_workflow',
+            )))
         self.failUnlessEqual(tuple(self.portal.my_worklist()), (document,))
 
         self.logout()


### PR DESCRIPTION
Need to test in combination with https://github.com/plone/plone.app.discussion/pull/116.