### PR TITLE
Fixed reinstall. [1.5.x]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,13 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed reinstall.  Deactivating and then activating the add-on
+  led to a missing tool and control panel icon.  Another deactivation
+  would then fail.  Solution is to mark our base profile as uninstalled
+  in the uninstall method.
+  This requires ``Products.GenericSetup`` 1.8.1 or higher.
+  Fixes `issue 1959 <https://github.com/plone/Products.CMFPlone/issues/1959>`_.
+  [maurits]
 
 
 1.5.14 (2017-01-17)

--- a/Products/CMFPlacefulWorkflow/Extensions/Install.py
+++ b/Products/CMFPlacefulWorkflow/Extensions/Install.py
@@ -53,4 +53,11 @@ def uninstall(self, reinstall=False, out=None):
     if IPlacefulMarker.providedBy(wf_tool):
         noLongerProvides(wf_tool, IPlacefulMarker)
 
+    # We need to tell portal_setup that the base profile
+    # has been unapplied, otherwise a reinstall will fail.
+    # See https://github.com/plone/Products.CMFPlone/issues/1959
+    portal_setup = getToolByName(self, 'portal_setup')
+    portal_setup.unsetLastVersionForProfile(
+        'profile-Products.CMFPlacefulWorkflow:base')
+
     return out.getvalue()

--- a/Products/CMFPlacefulWorkflow/tests/testCMFPlacefulWorkflow.py
+++ b/Products/CMFPlacefulWorkflow/tests/testCMFPlacefulWorkflow.py
@@ -128,6 +128,20 @@ class TestPlacefulWorkflow(CMFPlacefulWorkflowTestCase):
         """
         self.qi = self.portal.portal_quickinstaller
         self.qi.installProduct('CMFPlacefulWorkflow', reinstall=True)
+        self.assertTrue('portal_placeful_workflow' in self.portal)
+
+    def test_activation_reactivation(self):
+        """
+        Test if upgrade is going the good way
+        """
+        self.loginAsPortalOwner()
+        self.qi = self.portal.portal_quickinstaller
+        self.qi.uninstallProducts(['CMFPlacefulWorkflow'])
+        self.assertFalse('portal_placeful_workflow' in self.portal)
+        self.qi.installProduct('CMFPlacefulWorkflow')
+        self.assertTrue('portal_placeful_workflow' in self.portal)
+        self.qi.uninstallProducts(['CMFPlacefulWorkflow'])
+        self.assertFalse('portal_placeful_workflow' in self.portal)
 
     def test_prefs_workflow_policy_mapping_set_PostOnly(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,6 @@ setup(name='Products.CMFPlacefulWorkflow',
           'zope.i18nmessageid',
           'Products.CMFCore',
           'Products.CMFPlone',
-          'Products.GenericSetup',
+          'Products.GenericSetup>=1.8.1',
       ],
       )


### PR DESCRIPTION
Deactivating and then activating the add-on led to a missing tool and control panel icon.
Another deactivation would then fail.
Solution is to mark our base profile as uninstalled in the uninstall method.
This requires `Products.GenericSetup` 1.8.1 or higher.
Fixes https://github.com/plone/Products.CMFPlone/issues/1959.

This branch is used in Plone 4.3.
The same problem probably happens in 5.0 and 5.1 as well. I can look at that later.