### PR TITLE
Fixed reinstall. [1.6.x]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,13 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed reinstall.  Deactivating and then activating the add-on
+  led to a missing tool and control panel icon.  Another deactivation
+  would then fail.  Solution is to mark our base profile as uninstalled
+  in the uninstall method.
+  This requires ``Products.GenericSetup`` 1.8.1 or higher.
+  Fixes `issue 1959 <https://github.com/plone/Products.CMFPlone/issues/1959>`_.
+  [maurits]
 
 
 1.6.6 (2017-01-17)

--- a/Products/CMFPlacefulWorkflow/Extensions/Install.py
+++ b/Products/CMFPlacefulWorkflow/Extensions/Install.py
@@ -46,4 +46,11 @@ def uninstall(self, reinstall=False, out=None):
     if IPlacefulMarker.providedBy(wf_tool):
         noLongerProvides(wf_tool, IPlacefulMarker)
 
+    # We need to tell portal_setup that the base profile
+    # has been unapplied, otherwise a reinstall will fail.
+    # See https://github.com/plone/Products.CMFPlone/issues/1959
+    portal_setup = getToolByName(self, 'portal_setup')
+    portal_setup.unsetLastVersionForProfile(
+        'profile-Products.CMFPlacefulWorkflow:base')
+
     return out.getvalue()

--- a/Products/CMFPlacefulWorkflow/tests/testCMFPlacefulWorkflow.py
+++ b/Products/CMFPlacefulWorkflow/tests/testCMFPlacefulWorkflow.py
@@ -123,6 +123,20 @@ class TestPlacefulWorkflow(CMFPlacefulWorkflowTestCase):
         """
         self.qi = self.portal.portal_quickinstaller
         self.qi.installProduct('CMFPlacefulWorkflow', reinstall=True)
+        self.assertTrue('portal_placeful_workflow' in self.portal)
+
+    def test_activation_reactivation(self):
+        """
+        Test if upgrade is going the good way
+        """
+        self.loginAsPortalOwner()
+        self.qi = self.portal.portal_quickinstaller
+        self.qi.uninstallProducts(['CMFPlacefulWorkflow'])
+        self.assertFalse('portal_placeful_workflow' in self.portal)
+        self.qi.installProduct('CMFPlacefulWorkflow')
+        self.assertTrue('portal_placeful_workflow' in self.portal)
+        self.qi.uninstallProducts(['CMFPlacefulWorkflow'])
+        self.assertFalse('portal_placeful_workflow' in self.portal)
 
     def test_prefs_workflow_policy_mapping_set_PostOnly(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,6 @@ setup(name='Products.CMFPlacefulWorkflow',
           'zope.i18nmessageid',
           'Products.CMFCore',
           'Products.CMFPlone',
-          'Products.GenericSetup',
+          'Products.GenericSetup>=1.8.1',
       ],
       )


### PR DESCRIPTION
Deactivating and then activating the add-on led to a missing tool and control panel icon.
Another deactivation would then fail.
Solution is to mark our base profile as uninstalled in the uninstall method.
This requires `Products.GenericSetup` 1.8.1 or higher.
Fixes https://github.com/plone/Products.CMFPlone/issues/1959.

This is the forward port of #15.