### PR TITLE
Adapt tests to `Products.GenericSetup >= 2.0`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,14 @@
 Changelog
 =========
 
-1.7.6 (unreleased)
-------------------
+1.8 (unreleased)
+----------------
 
 Breaking changes:
 
-- *add item here*
+- Adapt tests to `Products.GenericSetup >= 2.0` thus requiring at least that
+  version.
+  [icemac]
 
 New features:
 

--- a/Products/CMFPlacefulWorkflow/tests/exportimport.txt
+++ b/Products/CMFPlacefulWorkflow/tests/exportimport.txt
@@ -79,7 +79,7 @@ The export produces a file for the tool itself::
 
     >>> print(archive.extractfile(
     ...     'portal_placeful_workflow.xml').read())
-    <?xml version="1.0"?>
+    <?xml version="1.0" encoding="utf-8"?>
     <object name="portal_placeful_workflow" meta_type="Placeful Workflow Tool">
      <property name="title"></property>
      <property name="max_chain_length" type="int">1</property>
@@ -94,7 +94,7 @@ The export produces a file for the tool itself::
 The export also produces a file for any policies::
 
     >>> print(archive.extractfile('portal_placeful_workflow/baz_policy.xml').read())
-    <?xml version="1.0"?>
+    <?xml version="1.0" encoding="utf-8"?>
     <object name="baz_policy" meta_type="WorkflowPolicy">
      <property name="title">Baz Policy</property>
      <bindings>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.7.6.dev0'
+version = '1.8.dev0'
 
 setup(
     name='Products.CMFPlacefulWorkflow',
@@ -38,6 +38,6 @@ setup(
         'zope.i18nmessageid',
         'Products.CMFCore',
         'Products.CMFPlone',
-        'Products.GenericSetup>=1.8.3',
+        'Products.GenericSetup >= 2.0.dev0',
     ],
 )


### PR DESCRIPTION
This is needed to get Plone 5.2 coredev buildout green again. After the Python 3 changes of `Products.GenericSetup` have been merged to master.