### PR TITLE
Do the permission checks in zcml.

### DIFF
--- a/Products/CMFPlacefulWorkflow/browser/configure.zcml
+++ b/Products/CMFPlacefulWorkflow/browser/configure.zcml
@@ -8,7 +8,7 @@
         name="placeful_workflow_configuration"
         class=".views.PlacefulWorkflowConfiguration"
         template="placeful_workflow_configuration.pt"
-        permission="zope2.View"
+        permission="CMFPlacefulWorkflow.ManageWorkflowPolicies"
         />
 
     <browser:page
@@ -16,7 +16,7 @@
         name="prefs_workflow_policy_mapping"
         class=".views.WorkflowPolicyMapping"
         template="prefs_workflow_policy_mapping.pt"
-        permission="zope2.View"
+        permission="CMFPlacefulWorkflow.ManageWorkflowPolicies"
         />
 
     <browser:page
@@ -24,8 +24,7 @@
         name="prefs_workflow_localpolicies_form"
         class=".views.WorkflowPoliciesForm"
         template="prefs_workflow_localpolicies_form.pt"
-        permission="zope2.View"
+        permission="CMFPlacefulWorkflow.ManageWorkflowPolicies"
         />
 
 </configure>
-

--- a/Products/CMFPlacefulWorkflow/browser/prefs_workflow_localpolicies_form.pt
+++ b/Products/CMFPlacefulWorkflow/browser/prefs_workflow_localpolicies_form.pt
@@ -11,8 +11,7 @@
 
         <span tal:define="dummy python:request.response.setHeader('pragma','no-cache')" />
 
-        <div id="content"
-             tal:condition="python:checkPermission('Manage portal', context)">
+        <div id="content">
 
             <h5 class="hiddenStructure">Views</h5>
 
@@ -154,13 +153,6 @@
 
             </div>
         </div>
-        <div id="content"
-             class="documentEditable"
-             tal:condition="python:not checkPermission('Manage portal', context)">
-            <tal:block replace="context/raiseUnauthorized" />
-        </div>
 
     </div>
 </html>
-
-

--- a/Products/CMFPlacefulWorkflow/browser/prefs_workflow_policy_mapping.pt
+++ b/Products/CMFPlacefulWorkflow/browser/prefs_workflow_policy_mapping.pt
@@ -15,8 +15,7 @@
 
         <span tal:define="dummy python:request.response.setHeader('pragma','no-cache')" />
 
-        <div id="content"
-             tal:condition="python:checkPermission('Manage portal', context)">
+        <div id="content">
 
             <h5 class="hiddenStructure">Views</h5>
 

--- a/Products/CMFPlacefulWorkflow/configure.zcml
+++ b/Products/CMFPlacefulWorkflow/configure.zcml
@@ -1,11 +1,11 @@
 <configure xmlns="http://namespaces.zope.org/zope"
     xmlns:zcml="http://namespaces.zope.org/zcml">
 
-  <include package=".browser"/>
   <include file="implements.zcml"/>
   <include file="exportimport.zcml"/>
   <include file="profiles.zcml"/>
   <include file="permissions.zcml"/>
+  <include package=".browser"/>
 
   <adapter factory=".adapter.PlacefulWorkflowChain" />
 

--- a/news/25.bugfix
+++ b/news/25.bugfix
@@ -1,0 +1,5 @@
+Do the permission checks in zcml.
+
+This means we can stop using the ``raiseUnauthorized`` skin script.
+Also check for the 'CMFPlacefulWorkflow: Manage workflow policies' permission instead of the 'Manage portal' permission.
+[maurits]


### PR DESCRIPTION
This means we can stop using the `raiseUnauthorized` skin script.
Also check for the 'CMFPlacefulWorkflow: Manage workflow policies' permission instead of the 'Manage portal' permission.
