### PR TITLE
Remove test of plone.app.discussion workflows. 

### DIFF
--- a/Products/CMFPlacefulWorkflow/tests/testCMFPlacefulWorkflow.py
+++ b/Products/CMFPlacefulWorkflow/tests/testCMFPlacefulWorkflow.py
@@ -607,9 +607,10 @@ class TestPlacefulWorkflow(CMFPlacefulWorkflowTestCase):
         document = self.portal.folder.document
         wf_tool.doActionFor(document, 'submit', comment="unittest transition")
 
-        keys = list(wf_tool.getWorklists().keys())
+        workflow_ids = list(wf_tool.getWorklists().keys())
 
-        default_workflows = sorted((
+        self.assertTrue(
+            all(elem in workflow_ids for elem in [
                 'comment_one_state_workflow',
                 'folder_workflow',
                 'intranet_folder_workflow',
@@ -617,9 +618,8 @@ class TestPlacefulWorkflow(CMFPlacefulWorkflowTestCase):
                 'one_state_workflow',
                 'plone_workflow',
                 'simple_publication_workflow',
-        ))
-        # default workflows are present
-        self.assertTrue(all(el in tuple(keys) for el in default_workflows))
+            ])
+        )
 
         self.assertEqual(tuple(wf_tool.getWorklistsResults()), (document, ))
 

--- a/Products/CMFPlacefulWorkflow/tests/testCMFPlacefulWorkflow.py
+++ b/Products/CMFPlacefulWorkflow/tests/testCMFPlacefulWorkflow.py
@@ -608,13 +608,8 @@ class TestPlacefulWorkflow(CMFPlacefulWorkflowTestCase):
         wf_tool.doActionFor(document, 'submit', comment="unittest transition")
 
         keys = list(wf_tool.getWorklists().keys())
-        if 'comment_review_workflow' in keys:
-            # This test needs to work on both 4.0 and 4.1
-            keys.remove('comment_review_workflow')
 
-        self.assertEqual(
-            sorted(tuple(keys)),
-            sorted((
+        default_workflows = sorted((
                 'comment_one_state_workflow',
                 'folder_workflow',
                 'intranet_folder_workflow',
@@ -622,7 +617,10 @@ class TestPlacefulWorkflow(CMFPlacefulWorkflowTestCase):
                 'one_state_workflow',
                 'plone_workflow',
                 'simple_publication_workflow',
-            )))
+        ))
+        # default workflows are present
+        self.assertTrue(all(el in tuple(keys) for el in default_workflows))
+
         self.assertEqual(tuple(wf_tool.getWorklistsResults()), (document, ))
 
         logout()

--- a/news/30.enhancement
+++ b/news/30.enhancement
@@ -1,0 +1,2 @@
+Remove test of plone.app.discussion workflows.
+[ksuess]


### PR DESCRIPTION
These tests belong to plone.app.discussion.


Reasen for this change: With changes on plone.app.discussions, an additonal workflow, tests of Products.CMFPlacefulWorkflow failed.