### PR TITLE
Fixed ModuleNotFoundError: No module named 'App.class_init' in Zope 5.

### DIFF
--- a/Products/CMFPlacefulWorkflow/DefaultWorkflowPolicy.py
+++ b/Products/CMFPlacefulWorkflow/DefaultWorkflowPolicy.py
@@ -22,7 +22,7 @@ A simple workflow policy.
 from AccessControl import ClassSecurityInfo
 from AccessControl.requestmethod import postonly
 from Acquisition import aq_base
-from App.class_init import InitializeClass
+from AccessControl.class_init import InitializeClass
 from os.path import join as path_join
 from Persistence import PersistentMapping
 from Products.CMFCore.utils import getToolByName

--- a/Products/CMFPlacefulWorkflow/PlacefulWorkflowTool.py
+++ b/Products/CMFPlacefulWorkflow/PlacefulWorkflowTool.py
@@ -23,7 +23,7 @@ from AccessControl import ClassSecurityInfo
 from AccessControl import Unauthorized
 from AccessControl.requestmethod import postonly
 from Acquisition import aq_parent
-from App.class_init import InitializeClass
+from AccessControl.class_init import InitializeClass
 from OFS.Folder import Folder
 from OFS.ObjectManager import IFAwareObjectManager
 from Products.CMFCore.interfaces import ISiteRoot

--- a/Products/CMFPlacefulWorkflow/WorkflowPolicyConfig.py
+++ b/Products/CMFPlacefulWorkflow/WorkflowPolicyConfig.py
@@ -23,7 +23,7 @@ from AccessControl import ClassSecurityInfo
 from Acquisition import aq_base
 from Acquisition import aq_inner
 from Acquisition import aq_parent
-from App.class_init import InitializeClass
+from AccessControl.class_init import InitializeClass
 from OFS.SimpleItem import SimpleItem
 from os.path import join as path_join
 from Products.CMFCore.utils import getToolByName

--- a/news/31.bugfix
+++ b/news/31.bugfix
@@ -1,0 +1,2 @@
+Fixed ModuleNotFoundError: No module named 'App.class_init' in Zope 5.
+[maurits]


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlacefulWorkflow/issues/31