### PR TITLE
Fix deprecation warning at startup for setDefaultRoles.

### DIFF
--- a/Products/CMFPlacefulWorkflow/permissions.py
+++ b/Products/CMFPlacefulWorkflow/permissions.py
@@ -2,7 +2,8 @@
 """ Zope 2 permissions
 """
 
-from Products.CMFCore.permissions import setDefaultRoles
+from AccessControl.Permission import addPermission
+
 
 ManageWorkflowPolicies = 'CMFPlacefulWorkflow: Manage workflow policies'
-setDefaultRoles(ManageWorkflowPolicies, ('Manager', 'Site Administrator'))
+addPermission(ManageWorkflowPolicies, ('Manager', 'Site Administrator'))

--- a/news/34.bugfix
+++ b/news/34.bugfix
@@ -1,0 +1,2 @@
+Fix deprecation warning at startup for setDefaultRoles.
+[maurits]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+long_description = file: README.rst, CHANGES.rst
+
 [zest.releaser]
 create-wheel = yes
 

--- a/setup.py
+++ b/setup.py
@@ -3,33 +3,12 @@ from setuptools import setup, find_packages
 version = '2.0.3.dev0'
 
 
-def read(filename):
-    with open(filename) as myfile:
-        try:
-            return myfile.read()
-        except UnicodeDecodeError:
-            # Happens on one Jenkins node on Python 3.6,
-            # so maybe it happens for users too.
-            pass
-    # Opening and reading as text failed, so retry opening as bytes.
-    with open(filename, "rb") as myfile:
-        contents = myfile.read()
-        return contents.decode("utf-8")
-
-
-long_description = "\n".join(
-    [
-        read("README.rst"),
-        read("CHANGES.rst"),
-    ]
-)
-
-
 setup(
     name='Products.CMFPlacefulWorkflow',
     version=version,
     description="Workflow policies for Plone",
-    long_description=long_description,
+    # Note: long_description is in setup.cfg
+    # to avoid needing workarounds for UnicodeDecodeErrors.
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Plone",

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,34 @@ from setuptools import setup, find_packages
 
 version = '2.0.3.dev0'
 
+
+def read(filename):
+    with open(filename) as myfile:
+        try:
+            return myfile.read()
+        except UnicodeDecodeError:
+            # Happens on one Jenkins node on Python 3.6,
+            # so maybe it happens for users too.
+            pass
+    # Opening and reading as text failed, so retry opening as bytes.
+    with open(filename, "rb") as myfile:
+        contents = myfile.read()
+        return contents.decode("utf-8")
+
+
+long_description = "\n".join(
+    [
+        read("README.rst"),
+        read("CHANGES.rst"),
+    ]
+)
+
+
 setup(
     name='Products.CMFPlacefulWorkflow',
     version=version,
     description="Workflow policies for Plone",
-    long_description=(open("README.rst").read() + "\n" +
-                      open("CHANGES.rst").read()),
+    long_description=long_description,
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Plone",


### PR DESCRIPTION
```
DeprecationWarning: setDefaultRoles is deprecated. Please use addPermission from AccessControl.Permission.
```

In CMFCore it is deprecated by zope.deferredimport, so we can just swap it.
master branch is only used in Plone 5.2, so it is safe to change.